### PR TITLE
LightGlue without cuda

### DIFF
--- a/lightglue/utils.py
+++ b/lightglue/utils.py
@@ -61,7 +61,10 @@ def load_image(path: Path, grayscale: bool = False, resize: int = None,
 
 def match_pair(extractor, matcher, image0, image1, scales0=None, scales1=None):
     device = image0.device
-    data = {'image0': image0[None].cuda(), 'image1': image1[None].cuda()}
+    if torch.cuda.is_available():
+        data = {'image0': image0[None].cuda(), 'image1': image1[None].cuda()}
+    else:
+        data = {'image0': image0[None], 'image1': image1[None]}
     img0, img1 = data['image0'], data['image1']
     feats0, feats1 = extractor({'image': img0}), extractor({'image': img1})
     pred = {**{k+'0': v for k, v in feats0.items()},
@@ -75,7 +78,9 @@ def match_pair(extractor, matcher, image0, image1, scales0=None, scales1=None):
     if scales1 is not None:
         pred['keypoints1'] = (pred['keypoints1'] + 0.5) / scales1[None] - 0.5
     del feats0, feats1
-    torch.cuda.empty_cache()
+    
+    if torch.cuda.is_available():
+        torch.cuda.empty_cache()
 
     # create match indices
     kpts0, kpts1 = pred['keypoints0'], pred['keypoints1']


### PR DESCRIPTION
When LightGlue use cuda (in lightglue.utils.match_pair function) check if torch.cuda.is_available() before use, else use cpu

````
def match_pair(extractor, matcher, image0, image1, scales0=None, scales1=None):
    device = image0.device
    if torch.cuda.is_available():
        data = {'image0': image0[None].cuda(), 'image1': image1[None].cuda()}
    else:
        data = {'image0': image0[None], 'image1': image1[None]}
   ....
   if torch.cuda.is_available():
        torch.cuda.empty_cache()
````