### PR TITLE
fix: func filter_matches issue, IndexError

### DIFF
--- a/lightglue/lightglue.py
+++ b/lightglue/lightglue.py
@@ -290,7 +290,7 @@ class MatchAssignment(nn.Module):
 
 
 def filter_matches(scores: torch.Tensor, th: float):
-    """ obtain matches from a log assignment matrix [Bx M+1 x N+1]"""
+    """obtain matches from a log assignment matrix [Bx M+1 x N+1]"""
     assert scores.shape.__len__() == 3
     max0, max1 = scores[:, :-1, :-1].max(2), scores[:, :-1, :-1].max(1)
     m0, m1 = max0.indices, max1.indices

--- a/lightglue/lightglue.py
+++ b/lightglue/lightglue.py
@@ -289,6 +289,7 @@ class MatchAssignment(nn.Module):
 
 def filter_matches(scores: torch.Tensor, th: float):
     """ obtain matches from a log assignment matrix [Bx M+1 x N+1]"""
+    assert scores.shape.__len__() == 3
     max0, max1 = scores[:, :-1, :-1].max(2), scores[:, :-1, :-1].max(1)
     m0, m1 = max0.indices, max1.indices
     indices0 = torch.arange(m0.shape[1], device=m0.device)[None]


### PR DESCRIPTION
when I input an image full of white or other pure colors, the scores tensor will have a dim less than 3, so the function filter_matches will have this IndexError error: max(): Expected reduction dim 0 to have non-zero size.