### PR TITLE
Fix docstring

### DIFF
--- a/lightglue/lightglue.py
+++ b/lightglue/lightglue.py
@@ -463,11 +463,11 @@ class LightGlue(nn.Module):
             matching_scores0: [B x M]
             matches1: [B x N]
             matching_scores1: [B x N]
-            matches: List[[Si x 2]],
+            matches: List[[Si x 2]]
             scores: List[[Si]]
-            stop: int,
-            prune0: [B x M],
-            prune1: [B x N] 
+            stop: int
+            prune0: [B x M]
+            prune1: [B x N]
         """
         with torch.autocast(enabled=self.conf.mp, device_type="cuda"):
             return self._forward(data)

--- a/lightglue/lightglue.py
+++ b/lightglue/lightglue.py
@@ -463,7 +463,11 @@ class LightGlue(nn.Module):
             matching_scores0: [B x M]
             matches1: [B x N]
             matching_scores1: [B x N]
-            matches: List[[Si x 2]], scores: List[[Si]]
+            matches: List[[Si x 2]],
+            scores: List[[Si]]
+            stop: int,
+            prune0: [B x M],
+            prune1: [B x N] 
         """
         with torch.autocast(enabled=self.conf.mp, device_type="cuda"):
             return self._forward(data)

--- a/lightglue/lightglue.py
+++ b/lightglue/lightglue.py
@@ -459,7 +459,6 @@ class LightGlue(nn.Module):
                 descriptors: [B x N x D]
                 image: [B x C x H x W] or image_size: [B x 2]
         Output (dict):
-            log_assignment: [B x M+1 x N+1]
             matches0: [B x M]
             matching_scores0: [B x M]
             matches1: [B x N]


### PR DESCRIPTION
Docstring for lightglue forward has leftover doc about `log_assignment`, which is not outputed anymore since refactor, and couple of more outputs were not documented

Actual output:
https://github.com/cvg/LightGlue/blob/main/lightglue/lightglue.py#L609