### PR TITLE
Adding the model weights to Hugging Face

### DIFF
--- a/lightglue/lightglue.py
+++ b/lightglue/lightglue.py
@@ -345,8 +345,7 @@ class LightGlue(nn.Module):
 
     required_data_keys = ["image0", "image1"]
 
-    version = "v0.1_arxiv"
-    url = "https://github.com/cvg/LightGlue/releases/download/{}/{}_lightglue.pth"
+    url = "https://huggingface.co/ariG23498/LightGlue/resolve/main/{}.pth"
 
     features = {
         "superpoint": {
@@ -414,9 +413,8 @@ class LightGlue(nn.Module):
 
         state_dict = None
         if features is not None:
-            fname = f"{conf.weights}_{self.version.replace('.', '-')}.pth"
             state_dict = torch.hub.load_state_dict_from_url(
-                self.url.format(self.version, features), file_name=fname
+                self.url.format(conf.weights)
             )
             self.load_state_dict(state_dict, strict=False)
         elif conf.weights is not None:

--- a/lightglue/superpoint.py
+++ b/lightglue/superpoint.py
@@ -141,7 +141,7 @@ class SuperPoint(Extractor):
             c5, self.conf.descriptor_dim, kernel_size=1, stride=1, padding=0
         )
 
-        url = "https://github.com/cvg/LightGlue/releases/download/v0.1_arxiv/superpoint_v1.pth"  # noqa
+        url = "https://huggingface.co/ariG23498/LightGlue/resolve/main/superpoint_v1.pth"  # noqa
         self.load_state_dict(torch.hub.load_state_dict_from_url(url))
 
         if self.conf.max_num_keypoints is not None and self.conf.max_num_keypoints <= 0:


### PR DESCRIPTION
Hey team!

I am Aritra, from Hugging Face. I have already uploaded all the model weights in the `.pth` format that were present in [this release](https://github.com/cvg/LightGlue/releases/tag/v0.1_arxiv) to my [personal namespace](https://huggingface.co/ariG23498/LightGlue) (I am open to transfering the models to a different name space if need be).

This is part of the ongoing talks to have an organization at Hugging Face for all models image matching. For more context one can refer to this [issue](https://github.com/alexstoken/image-matching-models/issues/45).

Currently we are also trying to [introduce `lightglue` as a custom library](https://github.com/huggingface/huggingface.js/pull/1837) to hub, so that we can track the downlaod of the models from the hub to get a better statistic.